### PR TITLE
1 - WPNNetworking is now public + small refactoring

### DIFF
--- a/Sources/Configuration/WDOConfigurationService.swift
+++ b/Sources/Configuration/WDOConfigurationService.swift
@@ -18,36 +18,7 @@ import WultraPowerAuthNetworking
 import PowerAuth2
 
 /// Service that provides configuration for the Wultra Digital Onboarding SDK.
-public class WDOConfigurationService {
-    
-    // MARK: - Dependencies and constants
-    
-    private let api: Networking
-    
-    // MARK: - Public initializers
-    
-    /// Creates service instance
-    /// - Parameters:
-    ///   - powerAuth: Configured PowerAuthSDK instance.
-    ///   - config: Configuration for the networking.
-    public convenience init(powerAuth: PowerAuthSDK, config: WPNConfig) {
-        self.init(
-            networking: WPNNetworkingService(powerAuth: powerAuth, config: config, serviceName: "WDOConfigurationNetworking")
-        )
-    }
-    
-    /// Creates service instance
-    /// - Parameters:
-    ///   - networking: Networking service for the onboarding server with configured PowerAuthSDK instance.
-    public convenience init(networking: WPNNetworkingService) {
-        self.init(api: .init(networking: networking))
-    }
-    
-    // MARK: - Private initializer
-    
-    init(api: Networking) {
-        self.api = api
-    }
+public class WDOConfigurationService: WDOBaseService {
     
     // MARK: - Public API
     

--- a/Sources/Onboarding/WDOActivationService.swift
+++ b/Sources/Onboarding/WDOActivationService.swift
@@ -27,7 +27,7 @@ private typealias ProcessData = (processId: String, activationCode: String?)
 /// and you will need to verify the PowerAuthSDK instance via `WDOVerificationService`.
 ///
 /// This service operates against Wultra Onboarding server (usually ending with `/enrollment-onboarding-server`) and you need to configure a networking service with the right URL.
-public class WDOActivationService {
+public class WDOActivationService: WDOBaseService {
     
     // MARK: - Public Properties
     
@@ -36,22 +36,6 @@ public class WDOActivationService {
     /// Note that even if this property is `true` it can be already discontinued on the server.
     /// Calling `status(completion:)` for example after the app is launched in this case is recommended.
     public var hasActiveProcess: Bool { processId != nil }
-    
-    /// Accept language for the outgoing requests headers.
-    /// The default value is "en".
-    ///
-    /// Standard RFC "Accept-Language" https://tools.ietf.org/html/rfc7231#section-5.3.5
-    /// Response texts are based on this setting. For example, when "de" is set, server
-    /// will return error texts and other in German (if available).
-    public var acceptLanguage: String {
-        get {
-            return api.networking.acceptLanguage
-        }
-        set {
-            D.debug("Setting new language for WDOActivationService: \(newValue)")
-            api.networking.acceptLanguage = newValue
-        }
-    }
     
     // MARK: - Private properties
     private var processData: ProcessData? {
@@ -78,7 +62,6 @@ public class WDOActivationService {
     
     // MARK: - Dependencies and constants
     
-    private let api: Networking
     private let keychainKey: String
     private let oq: OperationQueue = {
         let q = OperationQueue()
@@ -90,13 +73,14 @@ public class WDOActivationService {
     // MARK: - Public initializers
     
     /// Creates service instance
+    ///
     /// - Parameters:
     ///   - powerAuth: Configured PowerAuthSDK instance. This instance needs to be without valid activation.
-    ///   - config: Configuration for the networking.
+    ///   - networkingConfig: Configuration for the networking.
     ///   - canRestoreSession: If the activation session can be restored (when app restarts). `true` by default.
-    public convenience init(powerAuth: PowerAuthSDK, config: WPNConfig, canRestoreSession: Bool = true) {
+    public convenience init(powerAuth: PowerAuthSDK, networkingConfig: WPNConfig, canRestoreSession: Bool = true) {
         self.init(
-            networking: WPNNetworkingService(powerAuth: powerAuth, config: config, serviceName: "WDOActivationNetworking"),
+            networking: Self.createApi(powerAuth: powerAuth, networkingConfig: networkingConfig),
             canRestoreSession: canRestoreSession
         )
     }
@@ -106,14 +90,19 @@ public class WDOActivationService {
     ///   - networking: Networking service for the onboarding server with configured PowerAuthSDK instance that needs to be without valid activation.
     ///   - canRestoreSession: If the activation session can be restored (when app restarts). `true` by default.
     public convenience init(networking: WPNNetworkingService, canRestoreSession: Bool = true) {
-        self.init(api: .init(networking: networking), canRestoreSession: canRestoreSession)
+        self.init(
+            api: .init(
+                networking: networking
+            ),
+            canRestoreSession: canRestoreSession
+        )
     }
     
     // MARK: - Internal initializers
     
     init(api: Networking, canRestoreSession: Bool) {
-        self.api = api
         self.keychainKey = "wdopid_\(api.networking.powerAuth.configuration.instanceId)"
+        super.init(api: api)
         if canRestoreSession == false {
             processData = nil
         }

--- a/Sources/Verification/WDOVerificationService.swift
+++ b/Sources/Verification/WDOVerificationService.swift
@@ -25,28 +25,12 @@ import WultraPowerAuthNetworking
 /// This can be confirmed in the `PowerAuthActivationStatus.needVerification`, which will be `true`.
 ///
 /// This service operates against Wultra Onboarding server (usually ending with `/enrollment-onboarding-server`), and you need to configure a networking service with the right URL.
-public class WDOVerificationService {
+public class WDOVerificationService: WDOBaseService {
     
     // MARK: Public Properties
     
     /// Delegate that retrieves information about the verification and activation changes.
     public weak var delegate: WDOVerificationServiceDelegate?
-    
-    /// Accept language for the outgoing requests headers.
-    /// The default value is "en".
-    ///
-    /// Standard RFC "Accept-Language" https://tools.ietf.org/html/rfc7231#section-5.3.5
-    /// Response texts are based on this setting. For example, when "de" is set, server
-    /// will return error texts and other in German (if available).
-    public var acceptLanguage: String {
-        get {
-            return api.networking.acceptLanguage
-        }
-        set {
-            D.debug("Setting new language for WDOVerificationService: \(newValue)")
-            api.networking.acceptLanguage = newValue
-        }
-    }
     
     /// Type of the process.
     ///
@@ -55,7 +39,6 @@ public class WDOVerificationService {
 
     // MARK: - Private properties
 
-    private let api: Networking
     private var lastStatus: IdentityStatusResponse?
     // Cache key is scoped to the current process ID for isolation between processes.
     private var keychainKey: String? {
@@ -84,29 +67,6 @@ public class WDOVerificationService {
                 KeychainWrapper.standard.removeObject(forKey: key)
             }
         }
-    }
-    
-    // MARK: - Public initializers
-    
-    /// Creates service instance
-    /// - Parameters:
-    ///   - powerAuth: Configured PowerAuthSDK instance. This instance needs to have a valid activation.
-    ///   - config: Configuration of the networking service.
-    public convenience init(powerAuth: PowerAuthSDK, wpnConfig: WPNConfig) {
-        self.init(networking: .init(powerAuth: powerAuth, config: wpnConfig, serviceName: "WDOVerificationNetworking"))
-    }
-    
-    /// Creates service instance
-    /// - Parameters:
-    ///   - networking: Networking service for the onboarding server with configured PowerAuthSDK instance that needs to have a valid activation.
-    public convenience init(networking: WPNNetworkingService) {
-        self.init(api: .init(networking: networking))
-    }
-    
-    // MARK: - Private initializers
-    
-    init(api: Networking) {
-        self.api = api
     }
     
     // MARK: - Public API
@@ -903,21 +863,6 @@ public class WDOVerificationService {
         }
         completion(result)
     }
-    
-    // MARK: - Test Features
-    
-    #if DEBUG
-    /// Internal processing callback only for testing purposes!
-    /// This callback can be set only in DEBUG build and is called during the process.
-    /// Use this when some internal testing needs to be done during integration tests.
-    internal var _testing_Callback: ((_ name: String, _ data: Any) -> Void)?
-    #else
-    internal var _testing_Callback: ((_ name: String, _ data: Any) -> Void)? {
-        // no-op for non-debug
-        get { nil }
-        set { }
-    }
-    #endif
 }
 
 // MARK: - Other public APIs

--- a/Sources/WDOBaseService.swift
+++ b/Sources/WDOBaseService.swift
@@ -1,0 +1,103 @@
+//
+// Copyright 2026 Wultra s.r.o.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions
+// and limitations under the License.
+//
+
+import WultraPowerAuthNetworking
+import PowerAuth2
+
+/// Base class for main customer-facing services
+public class WDOBaseService {
+    
+    /// Accept language for the outgoing requests headers.
+    /// The default value is "en".
+    ///
+    /// Standard RFC "Accept-Language" https://tools.ietf.org/html/rfc7231#section-5.3.5
+    /// Response texts are based on this setting. For example, when "de" is set, server
+    /// will return error texts and other in German (if available).
+    public var acceptLanguage: String {
+        get {
+            return api.networking.acceptLanguage
+        }
+        set {
+            D.debug("Setting new language for \(Self.serviceName): \(newValue)")
+            api.networking.acceptLanguage = newValue
+        }
+    }
+    
+    /// Networking object that provides communication with the server.
+    public var networking: WPNNetworkingService { api.networking }
+    
+    internal let api: Networking
+    
+    // MARK: - Public initializers
+    
+    /// Creates service instance
+    ///
+    /// - Parameters:
+    ///   - powerAuth: Configured PowerAuthSDK instance.
+    ///   - networkingConfig: Configuration of the networking service.
+    public init(powerAuth: PowerAuthSDK, networkingConfig: WPNConfig) {
+        api = .init(
+            networking: Self.createApi(powerAuth: powerAuth, networkingConfig: networkingConfig)
+        )
+    }
+    
+    /// Creates service instance
+    ///
+    /// - Parameters:
+    ///   - networking: Networking service for the onboarding server with configured PowerAuthSDK instance.
+    public init(networking: WPNNetworkingService) {
+        api = .init(
+            networking: networking
+        )
+    }
+    
+    // MARK: - Private initializers
+    
+    init(api: Networking) {
+        self.api = api
+    }
+    
+    // MARK: - Test Features
+    
+    #if DEBUG
+    /// Internal processing callback only for testing purposes!
+    /// This callback can be set only in DEBUG build and is called during the process.
+    /// Use this when some internal testing needs to be done during integration tests.
+    internal var _testing_Callback: ((_ name: String, _ data: Any) -> Void)?
+    #else
+    internal var _testing_Callback: ((_ name: String, _ data: Any) -> Void)? {
+        // no-op for non-debug
+        get { nil }
+        set { }
+    }
+    #endif
+}
+
+// MARK: - Internal Helpers
+
+internal extension WDOBaseService {
+    /// Name of the service based on the type
+    static var serviceName: String { "\(self)" }
+
+    /// Helper factory method for WPNNetworkingService
+    static func createApi(powerAuth: PowerAuthSDK, networkingConfig: WPNConfig) -> WPNNetworkingService {
+        return .init(
+            powerAuth: powerAuth,
+            config: networkingConfig,
+            serviceName: "\(Self.serviceName)_networking"
+        )
+    }
+}

--- a/WultraDigitalOnboarding.xcodeproj/project.pbxproj
+++ b/WultraDigitalOnboarding.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		DC27FCA32F7BE5AF00D76F21 /* WDOBaseService.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC27FCA22F7BE5AA00D76F21 /* WDOBaseService.swift */; };
 		DC316C5A2F2CD9EB0046F169 /* WultraDigitalOnboarding.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DC75BB8E2A151FEB009C2901 /* WultraDigitalOnboarding.framework */; };
 		DC40301D2F47C038007755BE /* PowerAuth2.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = DC75BBC12A152344009C2901 /* PowerAuth2.xcframework */; };
 		DC40301E2F47C038007755BE /* PowerAuth2.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = DC75BBC12A152344009C2901 /* PowerAuth2.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
@@ -82,6 +83,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		DC27FCA22F7BE5AA00D76F21 /* WDOBaseService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WDOBaseService.swift; sourceTree = "<group>"; };
 		DC316C562F2CD9EB0046F169 /* WultraDigitalOnboardingTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = WultraDigitalOnboardingTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		DC402FEF2F45C247007755BE /* WDOHostApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = WDOHostApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		DC75BB8E2A151FEB009C2901 /* WultraDigitalOnboarding.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = WultraDigitalOnboarding.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -243,6 +245,7 @@
 				EAB4E7AD2ED882C6008BBDBF /* Configuration */,
 				DC75BBAC2A1521B0009C2901 /* Onboarding */,
 				DC75BB9D2A1521B0009C2901 /* Verification */,
+				DC27FCA22F7BE5AA00D76F21 /* WDOBaseService.swift */,
 				DC75BBAE2A1521B0009C2901 /* PowerAuthExtensions.swift */,
 				DC75BBA72A1521B0009C2901 /* WDOError.swift */,
 				DC75BB9B2A1521B0009C2901 /* WDOLogger.swift */,
@@ -468,6 +471,7 @@
 				DC75BBB42A1521B0009C2901 /* Networking.swift in Sources */,
 				DC75BBB32A1521B0009C2901 /* WDOVerificationService.swift in Sources */,
 				DC75BBCF2A152855009C2901 /* WDODocumentFile.swift in Sources */,
+				DC27FCA32F7BE5AF00D76F21 /* WDOBaseService.swift in Sources */,
 				DC75BBB72A1521B0009C2901 /* OnboardingObjects.swift in Sources */,
 				DC75BBB92A1521B0009C2901 /* DemoEndpoints.swift in Sources */,
 				DC75BBB82A1521B0009C2901 /* WDOError.swift in Sources */,

--- a/WultraDigitalOnboardingTests/HelperClasses.swift
+++ b/WultraDigitalOnboardingTests/HelperClasses.swift
@@ -43,9 +43,9 @@ class TestHelper {
         
         self.powerAuth = pa
         let url = URL(string: environment.esoUrl)!
-        self.activation = WDOActivationService(powerAuth: powerAuth, config: .init(baseUrl: url))
-        self.verification = WDOVerificationService(powerAuth: powerAuth, wpnConfig: .init(baseUrl: url))
-        self.configuration = WDOConfigurationService(powerAuth: powerAuth, config: .init(baseUrl: url))
+        self.activation = WDOActivationService(powerAuth: powerAuth, networkingConfig: .init(baseUrl: url))
+        self.verification = WDOVerificationService(powerAuth: powerAuth, networkingConfig: .init(baseUrl: url))
+        self.configuration = WDOConfigurationService(powerAuth: powerAuth, networkingConfig: .init(baseUrl: url))
         self.environment = environment
         self.processType = processType
     }

--- a/WultraDigitalOnboardingTests/IntegrationTests.swift
+++ b/WultraDigitalOnboardingTests/IntegrationTests.swift
@@ -80,6 +80,13 @@ class IntegrationTests: BaseTestClass {
         
         try await env.test { x in
             
+            // expect default language
+            #expect(x.verification.acceptLanguage == "en")
+            
+            // test language change
+            x.verification.acceptLanguage = "cs"
+            #expect(x.verification.acceptLanguage == "cs")
+            
             // start valid onboarding
             guard let (config, consentRequired) = try await x.startAndActivate() else {
                 return

--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -2,6 +2,7 @@
 
 ## TBA
 
+- This release requires Wultra Digital Onboarding server version 2.1 or higher.
 - Document scan flow no longer proceeds to processing when additional documents are still selected locally.
 - `SDKInitRequestAttributes` now contains `platform` and `origin` properties (mainly to support BlinkID SDK).
 - `WDOConfigurationService` allows to fetch Wultra Digital Onboarding configuration from the server. 
@@ -23,6 +24,8 @@
 - `WDOVerificationState.endstate` now carries optional `rejectReason` associated value with the server-provided rejection reason
 - `WDOVerificationService.status` now returns `WDOVerificationService.StatusResult` which includes the verification state alongside `processId` and `processType` server data
 - `WDOVerificationService.documentsSubmit` now automatically resolves `originalDocumentId` for files that don't provide it, based on previously cached process data (temporary workaround until solved on the backend)
+- `WDOActivationService`, `WDOVerificationService`, and `WDOConfigurationService` now inherit from `WDOBaseService`, which consolidates shared functionality (`acceptLanguage`, `networking`).
+- **Breaking:** Init parameter `config:` (on `WDOActivationService` and `WDOConfigurationService`) and `wpnConfig:` (on `WDOVerificationService`) renamed to `networkingConfig:` for consistency.
 
 ## 1.3.0 (October, 2024)
 

--- a/docs/Device-Activation.md
+++ b/docs/Device-Activation.md
@@ -24,7 +24,7 @@ Example with `PowerAuthSDK` instance:
 let powerAuth = PowerAuthSDK(configuration: ....)
 let activationService = WDOActivationService(
     powerAuth: powerAuth,
-    config: WPNConfig(baseUrl: "https://sever.my/path/"),
+    networkingConfig: WPNConfig(baseUrl: "https://sever.my/path/"),
     canRestoreSession: true
 )
 ```

--- a/docs/Device-Activation.md
+++ b/docs/Device-Activation.md
@@ -24,7 +24,7 @@ Example with `PowerAuthSDK` instance:
 let powerAuth = PowerAuthSDK(configuration: ....)
 let activationService = WDOActivationService(
     powerAuth: powerAuth,
-    networkingConfig: WPNConfig(baseUrl: "https://sever.my/path/"),
+    networkingConfig: WPNConfig(baseUrl: "https://server.my/path/"),
     canRestoreSession: true
 )
 ```
@@ -35,7 +35,7 @@ Example with `WPNNetworkingService ` instance:
 let powerAuth = PowerAuthSDK(configuration: ....)
 let networking = WPNNetworkingService(
     powerAuth: powerAuth, // configured PowerAuthSDK instance
-    config: WPNConfig(baseUrl: "https://sever.my/path/"),
+    config: WPNConfig(baseUrl: "https://server.my/path/"),
     serviceName: "MyProjectNetworkingService", // for better debugging
     acceptLanguage: "en" // more info in "Language Configuration" docs section
 )

--- a/docs/Language-Configuration.md
+++ b/docs/Language-Configuration.md
@@ -1,6 +1,6 @@
 # Language Configuration
 
-The language of content that might be localized can be configured via `acceptLanguage` property on both `WDOActivationService` and `WDOVerificationService`.
+The language of content that might be localized can be configured via `acceptLanguage` property on any service that inherits from `WDOBaseService` (`WDOActivationService`, `WDOVerificationService`, and `WDOConfigurationService`).
 
 The default language is `en`. Availability of languages depends on server configuration and implementation.
 

--- a/docs/Process-Configuration.md
+++ b/docs/Process-Configuration.md
@@ -13,7 +13,7 @@ Example:
 let powerAuth = PowerAuthSDK(configuration: ....)
 let configurationService = WDOConfigurationService(
     powerAuth: powerAuth,
-    config: WPNConfig(baseUrl: "https://server.me/path")
+    networkingConfig: WPNConfig(baseUrl: "https://server.me/path")
 )
 
 let processType = "onboarding" // defined on your server

--- a/docs/Verifying-User.md
+++ b/docs/Verifying-User.md
@@ -138,7 +138,7 @@ Example with `PowerAuthSDK` instance:
 let powerAuth = PowerAuthSDK(configuration: ....)
 let verification = WDOVerificationService(
     powerAuth: powerAuth,
-    networkingConfig: WPNConfig(baseUrl: "https://sever.my/path/")
+    networkingConfig: WPNConfig(baseUrl: "https://server.my/path/")
 )
 ```
 
@@ -148,7 +148,7 @@ Example with `WPNNetworkingService ` instance:
 let powerAuth = PowerAuthSDK(configuration: ....)
 let networking = WPNNetworkingService(
     powerAuth: powerAuth, // configured PowerAuthSDK instance
-    config: WPNConfig(baseUrl: "https://sever.my/path/"),
+    config: WPNConfig(baseUrl: "https://server.my/path/"),
     serviceName: "MyProjectNetworkingService", // for better debugging
     acceptLanguage: "en" // more info in "Language Configuration" docs section
 )

--- a/docs/Verifying-User.md
+++ b/docs/Verifying-User.md
@@ -138,7 +138,7 @@ Example with `PowerAuthSDK` instance:
 let powerAuth = PowerAuthSDK(configuration: ....)
 let verification = WDOVerificationService(
     powerAuth: powerAuth,
-    config: WPNConfig(baseUrl: "https://sever.my/path/")
+    networkingConfig: WPNConfig(baseUrl: "https://sever.my/path/")
 )
 ```
 


### PR DESCRIPTION
Fixed #44

- All services are now inherited from a base service, which provides shared features
- WPNNetworking is now public (which also provides a PowerAuth instance to the integrator)
- Added test for language (to also test if the service naming is OK)