### PR TITLE
Fixed #67: OTP resend period in config

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,44 @@
+# Copilot Instructions
+
+## Build, test, and lint
+
+| Task | Command | Notes |
+| --- | --- | --- |
+| Prepare local dependencies | `sh scripts/cart-update.sh` | Useful for initial setup and matches `.github/CONTRIBUTING.md`. The SDK is distributed via SPM and CocoaPods, but local development and CI still build Carthage dependencies. |
+| Build the SDK | `sh scripts/build.sh` | Builds the `WultraDigitalOnboarding` scheme in Release for iPhone Simulator. |
+| Run the full test suite | `./scripts/test.sh` | Runs the `WultraDigitalOnboardingTests` scheme on an auto-detected iOS simulator. |
+| Run tests with environment config | `./scripts/test.sh -config "$CONFIG_JSON"` | Writes the JSON into `WultraDigitalOnboardingTests/config.json` before running the tests. Integration tests depend on that file. |
+| Run a single test | `xcrun xcodebuild -project WultraDigitalOnboarding.xcodeproj -scheme WultraDigitalOnboardingTests -destination 'platform=iOS Simulator,name=<simulator>,OS=<ios-version>' -only-testing:WultraDigitalOnboardingTests/<SuiteName>/<TestName> test` | Use `xcrun xcodebuild -project WultraDigitalOnboarding.xcodeproj -scheme WultraDigitalOnboardingTests -showdestinations` to pick a valid simulator. Tests use Swift Testing suites from `WultraDigitalOnboardingTests/*.swift`, not XCTest case classes. |
+| Run SwiftLint | `sh scripts/swiftlint.sh` | Downloads and uses a repo-local `./swiftlint` binary (v0.53.0) and matches CI's strict lint run. |
+| Validate the podspec | `pod lib lint --allow-warnings` | Matches `.github/workflows/podlint.yml`. |
+
+`scripts/xcodeselect.sh` pins the CI Xcode selection. If local CLI builds behave differently from CI, compare your active Xcode with that script.
+
+## High-level architecture
+
+- This repo ships a single `WultraDigitalOnboarding` library (`Package.swift`) and builds on top of `PowerAuth2`, `PowerAuthCore`, and `WultraPowerAuthNetworking`. Current package metadata targets Swift 5.9 and iOS 13.
+- `Sources/API/Networking.swift` is the transport hub. It wraps one `WPNNetworkingService` and exposes three endpoint groups: `onboarding`, `identityVerification`, and `configuration`.
+- `WDOBaseService` is the shared base for all public services. It owns the shared `Networking` object and exposes the common `acceptLanguage` and `networking` surface.
+- `WDOActivationService` handles the pre-verification onboarding phase: start/status/cancel/activate/resendOTP. It persists `processId` and `activationCode` in Keychain under a key derived from the PowerAuth instance ID so activation can survive service recreation and app restarts.
+- `WDOConfigurationService` fetches the server-driven process configuration: OTP requirements, resend cooldown, temporary activation usage, and the allowed document groups/types.
+- `WDOVerificationService` handles the post-activation flow. Its `status()` call maps backend phase/status combinations to `WDOVerificationState`, and that state machine is the source of truth for which screen and API call comes next.
+- Document selection/upload state lives in `WDOVerificationScanProcess` and `WDOScannedDocument`. `WDOVerificationService` caches that per `processId` in Keychain so rejected uploads can be resubmitted with the correct server document IDs.
+- `PowerAuthExtensions.swift` adds onboarding-specific PowerAuth helpers such as `PowerAuthActivationStatus.needVerification` and activation helper wrappers.
+- `finishActivation(...)` is the final handoff when the backend uses temporary activation. It creates activation on a brand-new `PowerAuthSDK` instance; the original instance becomes unusable after success.
+- `WDOHostApp` is only a minimal host shell. The most representative integration behavior lives in `docs/*.md`, `WultraDigitalOnboardingTests/IntegrationTests.swift`, and `WultraDigitalOnboardingTests/HelperClasses.swift`.
+
+## Key conventions
+
+- Prefer the async APIs for new call sites. Public async methods mirror the callback APIs across activation, configuration, and verification.
+- The verification flow is server-driven. Do not hardcode a client-side happy path; call `status()` and switch over `WDOVerificationState`.
+- Get `processType`, document types, and OTP resend timing from `WDOConfigurationService`. Since 3.0, OTP resend cooldown comes from `WDOConfigurationResponse.otpResendPeriodSeconds`, not from `WDOVerificationState.otp`.
+- Use backend-provided document `type` strings (for example `ID_CARD`, `PASSPORT`) from configuration results when calling `documentsSetSelectedTypes(types:)`.
+- For document reuploads, preserve `originalDocumentId` by creating files from `WDOScannedDocument.createFileForUpload(...)` / `WDODocumentFile(scannedDocument:...)` when possible. `documentsSubmit` auto-fills missing original IDs from cached process data as a fallback, and that behavior is intentional.
+- Activation and verification state are expected to survive service recreation through Keychain-backed caches. After app relaunch or new service creation, resync with `status()` instead of assuming in-memory state is authoritative.
+- `finishActivation(...)` requires a fresh `PowerAuthSDK` instance that can start activation. After success, continue with the new instance, not the original one.
+- Keep localization on the shared service surface via `acceptLanguage`; do not bolt on custom request header handling for these services.
+- Verification errors are modeled as `WDOVerificationService.Fail`, which can carry a fallback `state`; activation/configuration errors are `WPNError`. Preserve that distinction instead of flattening everything into generic errors.
+- Logging uses `WDOLogger` (`D`) for SDK logs and `WPNLogger` for HTTP traffic. Be careful with debug logging because it may include sensitive request data.
+- Tests use the Swift Testing framework (`import Testing`, `@Test`, `#expect`), not XCTest. Integration tests iterate over every environment and `processType` loaded from `WultraDigitalOnboardingTests/config.json`, and the full onboarding flow assumes mocked downstream services.
+- Respect `.swiftlint.yml` as-is. The repo intentionally disables several common SwiftLint rules and excludes generated/build directories.
+- If a change affects public API or documented flow, keep `docs/SDK-Integration.md`, `docs/Process-Configuration.md`, `docs/Device-Activation.md`, `docs/Verifying-User.md`, `docs/Changelog.md`, and any relevant migration guide in sync.

--- a/Sources/API/Model/IdentityObjects.swift
+++ b/Sources/API/Model/IdentityObjects.swift
@@ -29,7 +29,6 @@ struct IdentityStatusResponse: Decodable {
         case processId = "processId"
         case processType = "processType"
         case rejectReason = "rejectReason"
-        case config = "config"
         case status = "identityVerificationStatus"
         case phase = "identityVerificationPhase"
         case consentRequired = "consentRequired"
@@ -42,12 +41,7 @@ struct IdentityStatusResponse: Decodable {
     let rejectReason: String?
     let status: IdentityVerificationStatus
     let phase: IdentityVerificationPhase?
-    let config: IdentityConfig
     let consentRequired: Bool?
-}
-
-struct IdentityConfig: Decodable {
-    let otpResendPeriodSeconds: Int
 }
 
 /// Status of the current identity verification

--- a/Sources/Configuration/WDOConfigurationObjects.swift
+++ b/Sources/Configuration/WDOConfigurationObjects.swift
@@ -29,6 +29,8 @@ public struct WDOConfigurationResponse: Codable {
     public let otpForIdentityVerification: Bool
     /// Is the onboarding process configured with temporary activation that should be exchanged for the permanent one.
     public let useTemporaryActivation: Bool
+    /// Time in seconds the user needs to wait between OTP resend calls.
+    public let otpResendPeriodSeconds: Int
     /// Documents required for identity verification.
     public let documents: WDOConfigurationDocuments
 }

--- a/Sources/Configuration/WDOConfigurationObjects.swift
+++ b/Sources/Configuration/WDOConfigurationObjects.swift
@@ -30,7 +30,8 @@ public struct WDOConfigurationResponse: Codable {
     /// Is the onboarding process configured with temporary activation that should be exchanged for the permanent one.
     public let useTemporaryActivation: Bool
     /// Time in seconds the user needs to wait between OTP resend calls.
-    public let otpResendPeriodSeconds: Int
+    /// `nil` when the backend doesn't provide the value.
+    public let otpResendPeriodSeconds: Int?
     /// Documents required for identity verification.
     public let documents: WDOConfigurationDocuments
 }

--- a/Sources/Verification/WDOVerificationService.swift
+++ b/Sources/Verification/WDOVerificationService.swift
@@ -182,7 +182,7 @@ public class WDOVerificationService: WDOBaseService {
                 case .statusCheck(let reason):
                     self.markCompleted(.success(makeResult(.processing(.from(reason)))), completion)
                 case .otp:
-                    self.markCompleted(.success(makeResult(.otp(remainingAttempts: nil, otpResendPeriodInSeconds: self.lastStatus?.config.otpResendPeriodSeconds))), completion)
+                    self.markCompleted(.success(makeResult(.otp(remainingAttempts: nil))), completion)
                 case .activationFinish:
                     self.markCompleted(.success(makeResult(.activationFinish)), completion)
                 case .failed:
@@ -662,7 +662,7 @@ public class WDOVerificationService: WDOBaseService {
                 } else {
                     if data.remainingAttempts > 0 && data.expired == false {
                         D.error("OTP not verified. Try again")
-                        self.markCompleted(.success(.otp(remainingAttempts: data.remainingAttempts, otpResendPeriodInSeconds: self.lastStatus?.config.otpResendPeriodSeconds)), completion)
+                        self.markCompleted(.success(.otp(remainingAttempts: data.remainingAttempts)), completion)
                     } else {
                         D.error("OTP not verified.")
                         self.markCompleted(.failure(.init(.init(reason: .wdo_verification_otpFailed))), completion)

--- a/Sources/Verification/WDOVerificationState.swift
+++ b/Sources/Verification/WDOVerificationState.swift
@@ -54,8 +54,7 @@ public enum WDOVerificationState: CustomStringConvertible {
     /// The OTP is usually SMS or email.
     ///
     /// - `remainingAttempts`: Number of remaining attempts to enter the correct OTP. Available after a failed OTP attempt.
-    /// - `otpResendPeriodInSeconds`: Time in seconds the user needs to wait between OTP resend calls. `nil` when not provided by the server.
-    case otp(remainingAttempts: Int?, otpResendPeriodInSeconds: Int?)
+    case otp(remainingAttempts: Int?)
     
     /// Show "finish activation" with PIN prompt screen.
     ///

--- a/WultraDigitalOnboarding.podspec
+++ b/WultraDigitalOnboarding.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name                  = 'WultraDigitalOnboarding'
-  s.version               = '2.0.0'
+  s.version               = '3.0.0'
   # Metadata
   s.license               = { :type => 'Apache License, Version 2.0', :file => 'LICENSE' }
   s.summary               = 'Wultra Digital Onboarding SDK'

--- a/WultraDigitalOnboardingTests/UnitTests.swift
+++ b/WultraDigitalOnboardingTests/UnitTests.swift
@@ -751,7 +751,35 @@ struct CodableModelTests {
         // round trip
         let reencoded = try JSONEncoder().encode(config)
         let redecoded = try JSONDecoder().decode(WDOConfigurationResponse.self, from: reencoded)
+        #expect(redecoded.otpResendPeriodSeconds == 30)
         #expect(redecoded.documents.totalRequiredDocumentsCount == 2)
+    }
+
+    @Test
+    func `WDOConfigurationResponse decodes without otp resend period for older backends`() throws {
+        let json = """
+        {
+            "enabled": true,
+            "otpForIdentification": false,
+            "otpForIdentityVerification": true,
+            "useTemporaryActivation": true,
+            "documents": {
+                "totalRequiredDocumentsCount": 1,
+                "groups": [
+                    {
+                        "requiredDocumentsCount": 1,
+                        "items": [
+                            { "type": "ID_CARD", "sideCount": 2, "country": "CZE" }
+                        ]
+                    }
+                ]
+            }
+        }
+        """.data(using: .utf8)!
+
+        let config = try JSONDecoder().decode(WDOConfigurationResponse.self, from: json)
+        #expect(config.otpResendPeriodSeconds == nil)
+        #expect(config.documents.totalRequiredDocumentsCount == 1)
     }
 
     @Test

--- a/WultraDigitalOnboardingTests/UnitTests.swift
+++ b/WultraDigitalOnboardingTests/UnitTests.swift
@@ -327,7 +327,7 @@ struct VerificationStateDescriptionTests {
             .processing(.clientAccepted),
             .processing(.onboardingApproval),
             .presenceCheck,
-            .otp(remainingAttempts: 3, otpResendPeriodInSeconds: 60),
+            .otp(remainingAttempts: 3),
             .activationFinish,
             .failed,
             .endstate(.rejected, rejectReason: "fraud"),
@@ -399,8 +399,7 @@ struct VerificationStatusTranslationTests {
         var json: [String: Any] = [
             "processId": "test-proc",
             "processType": "onboarding",
-            "identityVerificationStatus": status.rawValue,
-            "config": ["otpResendPeriodSeconds": 30]
+            "identityVerificationStatus": status.rawValue
         ]
         if let phase { json["identityVerificationPhase"] = phase.rawValue }
         if let consentRequired { json["consentRequired"] = consentRequired }
@@ -716,6 +715,7 @@ struct CodableModelTests {
             "otpForIdentification": false,
             "otpForIdentityVerification": true,
             "useTemporaryActivation": true,
+            "otpResendPeriodSeconds": 30,
             "documents": {
                 "totalRequiredDocumentsCount": 2,
                 "groups": [
@@ -736,6 +736,7 @@ struct CodableModelTests {
         #expect(config.otpForIdentification == false)
         #expect(config.otpForIdentityVerification == true)
         #expect(config.useTemporaryActivation == true)
+        #expect(config.otpResendPeriodSeconds == 30)
         #expect(config.documents.totalRequiredDocumentsCount == 2)
         #expect(config.documents.groups.count == 1)
         #expect(config.documents.groups[0].requiredDocumentsCount == 1)
@@ -754,7 +755,28 @@ struct CodableModelTests {
     }
 
     @Test
-    func `IdentityStatusResponse decodes with custom coding keys`() throws {
+    func `IdentityStatusResponse decodes without deprecated config`() throws {
+        let json = """
+        {
+            "processId": "abc-123",
+            "processType": "onboarding",
+            "identityVerificationStatus": "IN_PROGRESS",
+            "identityVerificationPhase": "DOCUMENT_UPLOAD",
+            "consentRequired": false
+        }
+        """.data(using: .utf8)!
+
+        let response = try JSONDecoder().decode(IdentityStatusResponse.self, from: json)
+        #expect(response.processId == "abc-123")
+        #expect(response.processType == "onboarding")
+        #expect(response.status == .inProgress)
+        #expect(response.phase == .documentUpload)
+        #expect(response.consentRequired == false)
+        #expect(response.rejectReason == nil)
+    }
+
+    @Test
+    func `IdentityStatusResponse ignores deprecated config when present`() throws {
         let json = """
         {
             "processId": "abc-123",
@@ -773,7 +795,6 @@ struct CodableModelTests {
         #expect(response.phase == .documentUpload)
         #expect(response.consentRequired == false)
         #expect(response.rejectReason == nil)
-        #expect(response.config.otpResendPeriodSeconds == 60)
     }
 
     @Test
@@ -923,6 +944,7 @@ struct ConfigurationDocumentSelectionTests {
             "otpForIdentification": false,
             "otpForIdentityVerification": false,
             "useTemporaryActivation": false,
+            "otpResendPeriodSeconds": 30,
             "documents": {
                 "totalRequiredDocumentsCount": 2,
                 "groups": [
@@ -961,6 +983,7 @@ struct ConfigurationDocumentSelectionTests {
             "otpForIdentification": false,
             "otpForIdentityVerification": false,
             "useTemporaryActivation": false,
+            "otpResendPeriodSeconds": 30,
             "documents": {
                 "totalRequiredDocumentsCount": 3,
                 "groups": [

--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 3.0.0 (TBA)
+
+- **⚠️ BREAKING**: `WDOVerificationState.otp` now carries only `remainingAttempts`.
+- `WDOConfigurationResponse` now includes `otpResendPeriodSeconds`.
+
 ## 2.0.0 (April, 2026)
 
 - This release requires enrollment onboarding server version 2.1.0 or higher.

--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -3,7 +3,7 @@
 ## 3.0.0 (TBA)
 
 - **⚠️ BREAKING**: `WDOVerificationState.otp` now carries only `remainingAttempts`.
-- `WDOConfigurationResponse` now includes `otpResendPeriodSeconds`.
+- `WDOConfigurationResponse` now includes optional `otpResendPeriodSeconds` (`nil` on older backends that do not provide the field yet).
 
 ## 2.0.0 (April, 2026)
 

--- a/docs/Migration-3.0.md
+++ b/docs/Migration-3.0.md
@@ -1,0 +1,34 @@
+# Migration from 2.x to 3.0.x
+
+This guide covers public API changes between `2.x` and `3.0.x`.
+
+## Breaking Changes
+
+1. Read OTP resend cooldown from configuration instead of verification status.
+
+```swift
+let configuration = try await configurationService.getConfiguration(processType: "onboarding")
+let otpResendPeriodSeconds = configuration.otpResendPeriodSeconds
+```
+
+2. Update OTP state handling.
+
+Before:
+
+```swift
+case .otp(let remainingAttempts, let otpResendPeriodInSeconds):
+    // use both values from verification status
+```
+
+After:
+
+```swift
+case .otp(let remainingAttempts):
+    // read resend cooldown from configuration.otpResendPeriodSeconds
+```
+
+## Checklist
+
+- Fetch and keep `WDOConfigurationResponse.otpResendPeriodSeconds` for the active process type.
+- Update `switch` statements and pattern matching for `WDOVerificationState.otp`.
+- Stop relying on OTP resend timing from `status()` results.

--- a/docs/Migration-3.0.md
+++ b/docs/Migration-3.0.md
@@ -11,6 +11,8 @@ let configuration = try await configurationService.getConfiguration(processType:
 let otpResendPeriodSeconds = configuration.otpResendPeriodSeconds
 ```
 
+`otpResendPeriodSeconds` is optional and can be `nil` when you are still integrating with an older backend that does not return the field yet.
+
 2. Update OTP state handling.
 
 Before:
@@ -29,6 +31,6 @@ case .otp(let remainingAttempts):
 
 ## Checklist
 
-- Fetch and keep `WDOConfigurationResponse.otpResendPeriodSeconds` for the active process type.
+- Fetch and keep `WDOConfigurationResponse.otpResendPeriodSeconds` for the active process type, and handle `nil` for older backends.
 - Update `switch` statements and pattern matching for `WDOVerificationState.otp`.
 - Stop relying on OTP resend timing from `status()` results.

--- a/docs/Migration-Guides.md
+++ b/docs/Migration-Guides.md
@@ -6,4 +6,5 @@ This page contains Wultra Digital Onboarding SDK migration instructions.
 When updating across multiple versions, apply all migration steps additively.
 <!-- end -->
 
+- [Migration from version `2.x` to `3.0.x`](Migration-3.0.md)
 - [Migration from version `1.3.x` to `2.0.x`](Migration-2.0.md)

--- a/docs/Process-Configuration.md
+++ b/docs/Process-Configuration.md
@@ -42,6 +42,8 @@ public struct WDOConfigurationResponse: Codable {
     public let otpForIdentityVerification: Bool
     /// Is the onboarding process configured with temporary activation that should be exchanged for the permanent one.
     public let useTemporaryActivation: Bool
+    /// Time in seconds the user needs to wait between OTP resend calls.
+    public let otpResendPeriodSeconds: Int
     /// Documents required for identity verification.
     public let documents: WDOConfigurationDocuments
 }
@@ -74,6 +76,8 @@ public struct WDOConfigurationDocument: Codable {
 ```
 
 `type` is a backend-defined string such as `ID_CARD` or `PASSPORT`.
+
+Use `otpResendPeriodSeconds` to drive the cooldown for `resendOTP()` in your activation or verification UI.
 
 ## Read next
 - [Device Activation](Device-Activation.md)

--- a/docs/Process-Configuration.md
+++ b/docs/Process-Configuration.md
@@ -43,7 +43,8 @@ public struct WDOConfigurationResponse: Codable {
     /// Is the onboarding process configured with temporary activation that should be exchanged for the permanent one.
     public let useTemporaryActivation: Bool
     /// Time in seconds the user needs to wait between OTP resend calls.
-    public let otpResendPeriodSeconds: Int
+    /// `nil` when the backend doesn't provide the value.
+    public let otpResendPeriodSeconds: Int?
     /// Documents required for identity verification.
     public let documents: WDOConfigurationDocuments
 }

--- a/docs/SDK-Integration.md
+++ b/docs/SDK-Integration.md
@@ -27,7 +27,7 @@ let package = Package(
         ),
     ],
     dependencies: [
-        .package(url: "https://github.com/wultra/digital-onboarding-apple.git", .from("2.0.0"))
+        .package(url: "https://github.com/wultra/digital-onboarding-apple.git", .from("3.0.0"))
     ],
     targets: [
         .target(
@@ -50,6 +50,7 @@ pod 'WultraDigitalOnboarding'
 
 | WDO SDK | PowerAuth SDK |  
 |---------|---------      |
+| `3.0.x` | `1.9.x`       |
 | `2.0.x` | `1.9.x`       |
 | `1.3.x` | `1.9.x`       |
 | `1.1.x` - `1.2.x` | `1.8.x`       |

--- a/docs/Verifying-User.md
+++ b/docs/Verifying-User.md
@@ -98,8 +98,7 @@ enum WDOVerificationState {
     /// The OTP is usually SMS or email.
     ///
     /// - `remainingAttempts`: Number of remaining attempts to enter the correct OTP. Available after a failed OTP attempt.
-    /// - `otpResendPeriodInSeconds`: Time in seconds the user needs to wait between OTP resend calls. `nil` when not provided by the server.
-    case otp(remainingAttempts: Int?, otpResendPeriodInSeconds: Int?)
+    case otp(remainingAttempts: Int?)
     
     /// Show "finish activation" with PIN prompt screen.
     ///
@@ -402,7 +401,7 @@ When this state is obtained, the following steps need to be done:
 
 After the presence check is finished, the user will receive an SMS/email OTP and the `otp` state will be reported. When this state is received, prompt the user for the OTP and verify it via `verifyOTP` method.
 
-The `otp` state also contains the number of remaining OTP attempts and the resend period in seconds. When attempts are depleted, the error state is returned.
+The `otp` state contains the number of remaining OTP attempts. The resend cooldown is available from `WDOConfigurationResponse.otpResendPeriodSeconds`, returned by `WDOConfigurationService.getConfiguration(processType:)`. When attempts are depleted, the error state is returned.
 
 Example:
 


### PR DESCRIPTION
Fixed #67

- OTP resend is now part of the config endpoint.
  - This is a breaking change and will be marked as version 3.0
- I also sneaked copilot instructions.