### PR TITLE
Expose ENABLE_ONBOARDING_DEMO to SPM consumers via package trait

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.9
+// swift-tools-version:6.1
 
 import PackageDescription
 
@@ -9,6 +9,12 @@ let package = Package(
     ],
     products: [
         .library(name: "WultraDigitalOnboarding", targets: ["WultraDigitalOnboarding"])
+    ],
+    traits: [
+        .trait(
+            name: "ENABLE_ONBOARDING_DEMO",
+            description: "Exposes demo-only getOTP endpoints for Wultra demo/mock servers. Do not enable in production."
+        )
     ],
     dependencies: [
         .package(url: "https://github.com/wultra/powerauth-mobile-sdk.git", .upToNextMinor(from: "2.0.0")),
@@ -24,5 +30,5 @@ let package = Package(
             path: "Sources"
         )
     ],
-    swiftLanguageVersions: [.v5]
+    swiftLanguageModes: [.v5]
 )

--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -2,7 +2,8 @@
 
 ## TBA
 
-- TBA
+- Raised the Swift Package Manager tools version to `6.1` (requires Xcode 16.3+).
+- The demo-only `getOTP()` endpoints are now exposed to SPM consumers through the `ENABLE_ONBOARDING_DEMO` package trait. Enable it on the package dependency to compile the demo endpoints in (off by default). See [SDK Integration](SDK-Integration.md#demo-endpoints-getotp).
 
 ## 3.1.0
 

--- a/docs/SDK-Integration.md
+++ b/docs/SDK-Integration.md
@@ -3,6 +3,7 @@
 ## Requirements
 
 - iOS 13.0+
+- Xcode 16.3+ (Swift Package Manager integration uses [package traits](https://github.com/swiftlang/swift-evolution/blob/main/proposals/0450-swiftpm-package-traits.md), which require the Swift 6.1 toolchain)
 - [PowerAuth Mobile SDK](https://github.com/wultra/powerauth-mobile-sdk) needs to be available in your project
 - [Enrollment Onboarding Server](https://developers.wultra.com/components/enrollment-server/develop/documentation/onboarding/index)
 
@@ -13,7 +14,7 @@ Add `https://github.com/wultra/digital-onboarding-apple` repository as a package
 Alternatively, you can add the dependency manually. For example:
 
 ```swift
-// swift-tools-version:5.9
+// swift-tools-version:6.1
 import PackageDescription
 let package = Package(
     name: "YourLibrary",
@@ -45,6 +46,53 @@ Add the following dependencies to your Podfile:
 
 ```rb
 pod 'WultraDigitalOnboarding'
+```
+
+## Demo endpoints (`getOTP`)
+
+For testing against Wultra demo/mock servers, the SDK offers demo-only
+`WDOActivationService.getOTP(...)` and `WDOVerificationService.getOTP(...)` methods that
+retrieve the OTP directly, without waiting for an SMS or email. These are guarded by the
+`ENABLE_ONBOARDING_DEMO` compilation flag and are **not** compiled in by default, so they
+never ship in production builds.
+
+> ⚠️ Never enable this in a production application. The demo endpoints are only available on
+> Wultra demo/mock deployments.
+
+### Swift Package Manager
+
+Unlike CocoaPods, SPM has no `post_install` hook to inject a compilation flag into a
+dependency, and compilation conditions never propagate from your app to a package's target.
+Instead, the flag is exposed as a **package trait** named `ENABLE_ONBOARDING_DEMO`. Enable it
+on the dependency (this works in any build configuration, not just `debug`):
+
+```swift
+dependencies: [
+    .package(
+        url: "https://github.com/wultra/digital-onboarding-apple.git",
+        .from("VERSION_DEFINITION"),
+        traits: [.defaults, "ENABLE_ONBOARDING_DEMO"]
+    )
+]
+```
+
+If you add the SDK through the Xcode UI, enable the `ENABLE_ONBOARDING_DEMO` trait in the
+package dependency's trait selection (Xcode 16.3+).
+
+### CocoaPods
+
+Keep enabling the flag from your `Podfile` `post_install` hook, for example:
+
+```rb
+post_install do |installer|
+  installer.pods_project.targets.each do |target|
+    next unless target.name == 'WultraDigitalOnboarding'
+    target.build_configurations.each do |config|
+      config.build_settings['SWIFT_ACTIVE_COMPILATION_CONDITIONS'] ||= '$(inherited)'
+      config.build_settings['SWIFT_ACTIVE_COMPILATION_CONDITIONS'] << ' ENABLE_ONBOARDING_DEMO'
+    end
+  end
+end
 ```
 
 ## Async/Await

--- a/docs/SDK-Integration.md
+++ b/docs/SDK-Integration.md
@@ -29,7 +29,7 @@ let package = Package(
     ],
     dependencies: [
         // Replace VERSION_DEFINITION with the actual package version.
-        .package(url: "https://github.com/wultra/digital-onboarding-apple.git", .from("VERSION_DEFINITION"))
+        .package(url: "https://github.com/wultra/digital-onboarding-apple.git", from: "VERSION_DEFINITION")
     ],
     targets: [
         .target(
@@ -53,8 +53,7 @@ pod 'WultraDigitalOnboarding'
 For testing against Wultra demo/mock servers, the SDK offers demo-only
 `WDOActivationService.getOTP(...)` and `WDOVerificationService.getOTP(...)` methods that
 retrieve the OTP directly, without waiting for an SMS or email. These are guarded by the
-`ENABLE_ONBOARDING_DEMO` compilation flag and are **not** compiled in by default, so they
-never ship in production builds.
+`ENABLE_ONBOARDING_DEMO` compilation flag and are **not** compiled in by default.
 
 > ⚠️ Never enable this in a production application. The demo endpoints are only available on
 > Wultra demo/mock deployments.
@@ -70,7 +69,7 @@ on the dependency (this works in any build configuration, not just `debug`):
 dependencies: [
     .package(
         url: "https://github.com/wultra/digital-onboarding-apple.git",
-        .from("VERSION_DEFINITION"),
+        from: "VERSION_DEFINITION",
         traits: [.defaults, "ENABLE_ONBOARDING_DEMO"]
     )
 ]


### PR DESCRIPTION
## Summary

Exposes the demo-only `getOTP()` endpoints to **Swift Package Manager** consumers.

SPM has no equivalent to the CocoaPods `post_install` hook, and compilation conditions (`-D` / `SWIFT_ACTIVE_COMPILATION_CONDITIONS`) **do not propagate** from a consuming app to a dependency's target. As a result, an app could set `ENABLE_ONBOARDING_DEMO` but the flag never reached the SDK target — so the `#if ENABLE_ONBOARDING_DEMO`-guarded `getOTP()` methods were always compiled out, and the OTP couldn't be retrieved from demo/mock servers.

This PR exposes the flag as a **Swift Package Manager package trait** ([SE-0450](https://github.com/swiftlang/swift-evolution/blob/main/proposals/0450-swiftpm-package-traits.md)) named `ENABLE_ONBOARDING_DEMO`. The consuming app enables it directly on the package dependency, in **any build configuration** (not just `debug`). The trait name matches the existing compilation condition, so **no source changes** were needed.

## Changes

- **`Package.swift`**
  - Bumped `swift-tools-version` `5.9 → 6.1` (required for package traits).
  - Renamed `swiftLanguageVersions` → `swiftLanguageModes` (tools 6.1 rename).
  - Declared the `ENABLE_ONBOARDING_DEMO` trait, **off by default** — demo endpoints never ship in production builds.
- **Docs**
  - `SDK-Integration.md`: updated requirements (Xcode 16.3+), the SPM manifest example, and a new **Demo endpoints (`getOTP`)** section covering both SPM traits and the CocoaPods `post_install` hook.
  - `Changelog.md`: added a `TBA` entry.

## How consumers enable it

**Swift Package Manager**
```swift
.package(
    url: "https://github.com/wultra/digital-onboarding-apple.git",
    from: "x.y.z",
    traits: [.defaults, "ENABLE_ONBOARDING_DEMO"]
)

Or, when adding the SDK through the Xcode UI, tick the  ENABLE_ONBOARDING_DEMO  trait in the package dependency's trait selection (Xcode 16.3+).

CocoaPods — unaffected; keep enabling the flag via your existing  post_install  hook.

Breaking change

⚠️ The SPM tools version bump to  6.1  raises the minimum Xcode to 16.3 for SPM consumers.